### PR TITLE
fix: overlay page init

### DIFF
--- a/public/overlay.css
+++ b/public/overlay.css
@@ -1,0 +1,26 @@
+* {
+  background-color: transparent;
+}
+
+body {
+  margin: 0;
+}
+
+:root {
+  --tb-height: 30px;
+}
+
+#toolbar {
+  height: var(--tb-height);
+  background-color: darkslategrey;
+  color: white;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+#contents {
+  margin-top: var(--tb-height);
+  opacity: 1;
+}

--- a/public/overlay.html
+++ b/public/overlay.html
@@ -4,10 +4,18 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Overlay</title>
-    <script type="module" src="./overlay.js"></script>
+    <link rel="stylesheet" href="./overlay.css" />
   </head>
   <body>
-    <h1 id="title"></h1>
-    <img id="main-image" />
+    <div id="toolbar">
+      <div>
+        <input id="opacity-input" type="range" min="0" max="100" value="100" step="1" />
+        <span id="opacity-value"></span>
+      </div>
+    </div>
+    <div id="contents">
+      <img id="main-image" />
+    </div>
+    <script type="module" src="./overlay.js"></script>
   </body>
 </html>

--- a/public/overlay.js
+++ b/public/overlay.js
@@ -1,12 +1,34 @@
-import { listen } from "./node_modules/@tauri-apps/api/event";
+import { once, emit } from "/node_modules/@tauri-apps/api/event";
+
+const PAGE_LOADED_EVENT = "PageLoaded";
+const DISPLAY_IMG_EVENT = "DisplayImg";
+
+const opacityValueEl = document.querySelector("span#opacity-value");
+const contentsEl = document.querySelector("#contents");
+const contentMainImgEl = document.querySelector("img#main-image");
+
+function addDomEvents() {
+  document
+    .querySelector("input#opacity-input")
+    .addEventListener("input", updateRange);
+}
+
+function updateRange(e) {
+  opacityValueEl.innerText = e.target.value;
+  contentsEl.style["opacity"] = e.target.value / 100;
+}
+
+function onReceiveB64(receivedEvent) {
+  contentMainImgEl["src"] = receivedEvent.payload;
+}
+
+function notifyPageLoaded() {
+  emit(PAGE_LOADED_EVENT, { isLoaded: true });
+  console.log("notified");
+}
 
 await (async function init() {
-  console.log("Init");
-
-  const unlisten = await listen("DisplayImg", (receivedEvent) => {
-    console.log("totus", receivedEvent.payload);
-    window.b64 = receivedEvent.payload;
-    document.querySelector("img#main-image")["src"] =
-      receivedEvent.payload;
-  });
+  addDomEvents();
+  await once(DISPLAY_IMG_EVENT, onReceiveB64);
+  notifyPageLoaded();
 })();

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-build = { version = "1.1", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.1", features = ["dialog-all", "fs-all"] }
+tauri = { version = "1.1", features = ["dialog-all", "fs-all", "window-all"] }
 base64 = "0.13.0"
 
 [features]

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,60 +1,16 @@
-extern crate base64;
+use base64;
 
 pub fn get_b64_from_uint8(buffer: Vec<u8>) -> String {
     return base64::encode(buffer);
 }
 
 pub fn create_window(handle: tauri::AppHandle) {
-    let local_window = tauri::WindowBuilder::new(
+    tauri::WindowBuilder::new(
         &handle,
         "overlay",
         tauri::WindowUrl::App("overlay.html".into()),
-    ).build().unwrap();
- 
-    // let docs_window = tauri::WindowBuilder::new(
-    //     &handle,
-    //     "overlay",
-    //     tauri::WindowUrl::App("overlay.html".into()),
-    // )
-    // .build()
-    // .unwrap();
-
-    // let app = tauri::Builder::default()
-    //     .build(tauri::generate_context!())z
-    //     .expect("error while building tauri application");
-
-    // let docs_window = tauri::WindowBuilder::new(
-    //     &app,
-    //     "external", /* the unique window label */
-    //     tauri::WindowUrl::External("https://tauri.app/".parse().unwrap()),
-    // )
-    // .build()
-    // .expect("failed to build window");
-
-    // let local_window =
-    //     tauri::WindowBuilder::new(&app, "local", tauri::WindowUrl::App("overlay.html".into()));
-
-    //    let lol =  local_window.build();
+    )
+    .transparent(true)
+    .build()
+    .unwrap();
 }
-
-// tauri::Builder::default().setup(|app| {
-//     tauri::WindowBuilder::new(app, "overlay", tauri::WindowUrl::App("overlay.html".into()))
-//         .build()?;
-//     Ok(())
-//     // Err(error) => {
-//     //     panic!("error",error)
-//     // };
-// });
-
-// tauri::Builder::default().setup(|app| {
-//     let overlay_window = tauri::WindowBuilder::new(
-//         app,
-//         "overlay", /* the unique window label */
-//         tauri::WindowUrl::App("overlay.html".parse().unwrap()),
-//     )
-//     .build()?;
-//     let local_window =
-//         tauri::WindowBuilder::new(app, "local", tauri::WindowUrl::App("index.html".into()))
-//             .build()?;
-//     Ok(())
-// })

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,9 @@
       "fs": {
        "all":true,
        "scope": ["**"]
+      },
+      "window":{
+        "all":true
       }
     },
     "bundle": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { open } from "@tauri-apps/api/dialog";
 import { invokeOpenOverlay, invokeReadFileAsb64 } from "./interop";
 import { getFileExtention, isAcceptableFiletype } from "./utils";
 import "./App.css";
-import { sendDisplayImg } from "./services/window.service";
+import { listenToPageLoaded } from "./services/window.service";
 
 function App() {
   const [currentPath, setCurrentPath] = useState<string>("");
@@ -47,7 +47,7 @@ function App() {
 
   async function openOverlay(index: number) {
     await invokeOpenOverlay();
-    sendDisplayImg(`data:image/png;base64,${images[index]}`);
+    await listenToPageLoaded(`data:image/png;base64,${images[index]}`)
   }
 
   return (

--- a/src/interop/index.ts
+++ b/src/interop/index.ts
@@ -4,6 +4,6 @@ export async function invokeReadFileAsb64(path: string): Promise<string> {
   return invoke("read_file", { path });
 }
 
-export async function invokeOpenOverlay(): Promise<never> {
+export async function invokeOpenOverlay(){
   return invoke("open_overlay");
 }

--- a/src/services/window.service.ts
+++ b/src/services/window.service.ts
@@ -4,13 +4,35 @@ const overlayWindowId = "overlay";
 
 enum OverlayEvent {
   DisplayImg = "DisplayImg",
+  PageLoaded = "PageLoaded",
 }
 
 const getOverlayWindow = () => WebviewWindow.getByLabel(overlayWindowId);
 
-export const sendDisplayImg = (b64: string) => {
-  const overlayWindow = getOverlayWindow();
-  if (!window) return;
+let currentUnlistenFn:Function;
 
-  overlayWindow?.emit(OverlayEvent.DisplayImg, b64);
+export const sendDisplayImg = async (b64: string) => {
+  const overlayWindow = getOverlayWindow();
+  if (!overlayWindow) return;
+
+  await overlayWindow.emit(OverlayEvent.DisplayImg, b64);
+};
+
+export const listenToPageLoaded = async (b64: string) => {
+
+  const overlayWindow = getOverlayWindow();
+  if (!overlayWindow) return;
+
+  if (currentUnlistenFn) currentUnlistenFn();
+
+  console.log('listen1');
+
+  currentUnlistenFn = await overlayWindow.listen(
+    OverlayEvent.PageLoaded,
+    async () => {
+  console.log('PageLoaded');
+
+      await overlayWindow.emit(OverlayEvent.DisplayImg, b64);
+    }
+  );
 };


### PR DESCRIPTION
overlay send an init event so b64 can be sent back commands should be async
window decoration can be displayed but bg bug occuring